### PR TITLE
Remove usage of unstable features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: rust
 
 rust:
         - nightly
+        - beta
+        - stable
 install:
         - git clone https://github.com/aquynh/capstone
         - (cd capstone && git checkout 3.0.1 && sudo make install)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ authors = ["Michael Gehring <mg@ebfe.org>"]
 
 [dependencies]
 bitflags = "*"
+libc = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,12 @@
 #![crate_name="capstone"]
 #![crate_type="rlib"]
-#![feature(core, libc)]
 
 extern crate libc;
-extern crate core;
 
 #[macro_use] extern crate bitflags;
 
 use libc::{c_int, c_void, size_t};
 use std::ffi::CStr;
-use std::mem;
-use std::raw::Slice;
 use std::str::from_utf8;
 
 mod ll;
@@ -112,7 +108,7 @@ impl Engine {
                 0 => Err(Error::new(self.errno())),
                 n => {
                     let mut v = Vec::new();
-                    let cinsn : &[ll::cs_insn] = mem::transmute(Slice{ data: cinsnptr, len: n as usize});
+                    let cinsn : &[ll::cs_insn] = std::slice::from_raw_parts(cinsnptr, n as usize);
                     v.extend(cinsn.iter().map(|ci| {
                         Insn{
                             addr:     ci.address,


### PR DESCRIPTION
This allows the library to compile without any `#[feature]` annotations for me, and it should work on Rust stable.