### PR TITLE
Fixing for last bitflags version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.0.0"
 authors = ["Michael Gehring <mg@ebfe.org>"]
 
 [dependencies]
-bitflags = "*"
+bitflags = "0.5"
 libc = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub enum Arch {
 }
 
 bitflags!(
-    flags Mode: u32 {
+    pub flags Mode: u32 {
         const MODE_LITTLE_ENDIAN= 0,
         const MODE_ARM          = 0,
         const MODE_16           = 1 << 1,


### PR DESCRIPTION
bitflags version 0.5 doesn't make structs public by default any more and Mode has to be public because it's in an exported API.
I'm fixing bitflags version to 0.5 in Cargo.toml (for stability) and updating lib.rs.

As a side note, it would be good to fix libc version too (for stability again).
